### PR TITLE
NGPOC-86: Fetch and register previous encounter for historical values

### DIFF
--- a/src/app/abstract-controls-extension/afe-form-control.ts
+++ b/src/app/abstract-controls-extension/afe-form-control.ts
@@ -1,4 +1,4 @@
-import { FormControl, ValidatorFn, AsyncValidatorFn, AbstractControl } from '@angular/forms';
+import { FormControl, ValidatorFn, AsyncValidatorFn } from '@angular/forms';
 
 import { ControlRelations } from '../change-tracking/control-relations';
 
@@ -7,7 +7,7 @@ import { CanDisable, Disabler } from '../form-entry/control-hiders-disablers/can
 import { HiderHelper } from '../form-entry/control-hiders-disablers/hider-helpers';
 import { DisablerHelper } from '../form-entry/control-hiders-disablers/disabler-helper';
 import { CanCalculate } from '../form-entry/control-calculators/can-calculate';
-import { Runnable } from '../form-entry/expression-runner/expression-runner';
+import { ExpressionRunner } from '../form-entry/expression-runner/expression-runner';
 
 export class AfeFormControl extends FormControl implements CanHide, CanDisable, CanCalculate {
     private _controlRelations: ControlRelations;
@@ -51,7 +51,7 @@ export class AfeFormControl extends FormControl implements CanHide, CanDisable, 
 
     updateCalculatedValue() {
       if (this.calculator) {
-        let _val = this.calculator.call(Runnable, {});
+        let _val = this.calculator.call(ExpressionRunner, {});
         if (this.value === '') {
           this.setValue(_val);
         }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { FormGroup } from '@angular/forms';
 import { Form } from './form-entry/form-factory/form';
 import { FormFactory } from './form-entry/form-factory/form.factory';
 import { ObsPayloadFactoryService } from './form-entry/services/obs-payload-factory.service';
+import { MockObs } from './mock/mock-obs';
 
 const adultForm = require('./adult');
 const adultFormObs = require('./mock/obs');
@@ -55,7 +56,8 @@ export class AppComponent implements OnInit {
     }
 
     createForm() {
-        this.form = this.formFactory.createForm(this.schema);
+        let obs = new MockObs();
+        this.form = this.formFactory.createForm(this.schema, obs.getObs());
     }
 
     onSubmit($event) {

--- a/src/app/form-entry/form-factory/form-control.service.spec.ts
+++ b/src/app/form-entry/form-factory/form-control.service.spec.ts
@@ -271,7 +271,7 @@ describe('Form Factory Control Service Tests', () => {
 
     let control3 = formControlService.generateFormControl(bmiQuestion);
 
-    control3.controlRelations.addRelatedControls([control1,control2]);
+    control3.controlRelations.addRelatedControls([control1, control2]);
     // this will trigger propagateChange() function in the controls
     control1.setValue(180);
     control2.setValue(70);

--- a/src/app/form-entry/form-factory/form.factory.ts
+++ b/src/app/form-entry/form-factory/form.factory.ts
@@ -22,9 +22,12 @@ export class FormFactory {
       public questionFactroy: QuestionFactory, public controlRelationsFactory: ControlRelationsFactory) {
     }
 
-    createForm(schema: any): Form {
+    createForm(schema: any, dataSource?: any): Form {
         let form: Form = new Form(schema, this, this.questionFactroy);
-        let question = this.questionFactroy.createQuestionModel(schema);
+        if (dataSource) {
+          form.dataSourcesContainer.registerDataSource('rawPrevEnc', dataSource);
+        }
+        let question = this.questionFactroy.createQuestionModel(schema, form);
         form.rootNode = this.createNode(question, null, null, form) as GroupNode;
 
         this.buildRelations(form.rootNode);

--- a/src/app/form-entry/form-factory/question.factory.ts
+++ b/src/app/form-entry/form-factory/question.factory.ts
@@ -16,12 +16,19 @@ import { DateValidationModel } from '../question-models/date-validation.model';
 import { JsExpressionValidationModel } from '../question-models/js-expression-validation.model';
 import { DummyDataSource } from '../data-sources/dummy-data-source';
 import { HistoricalHelperService } from '../helpers/historical-expression-helper-service';
+import { Form } from './form';
 
 export class QuestionFactory {
+  dataSources: any = {};
+  historicalHelperService: HistoricalHelperService = new HistoricalHelperService();
   constructor() {
   }
 
-  createQuestionModel(formSchema: any): QuestionBase {
+  createQuestionModel(formSchema: any, form?: Form): QuestionBase {
+    if (form) {
+      let dataSources = form.dataSourcesContainer.dataSources;
+      this.dataSources = dataSources;
+    }
     return this.toFormQuestionModel(formSchema);
   }
 
@@ -506,21 +513,14 @@ export class QuestionFactory {
   }
 
   addHistoricalExpressions(schemaQuestion: any, question: QuestionBase): any {
-
     if (schemaQuestion.historicalExpression && schemaQuestion.historicalExpression.length > 0) {
-
       question['hasHistoricalValue'] = true;
-
-      let helper = new HistoricalHelperService();
-      let origValue = helper.evaluate(schemaQuestion.historicalExpression);
-
+      let origValue = this.historicalHelperService.evaluate(schemaQuestion.historicalExpression, this.dataSources);
       question['historicalDataValue'] = origValue;
       if (schemaQuestion.historicalPrepopulate) {
-
         question.defaultValue = origValue;
       }
     }
-
   }
 
   addCalculatorProperty(schemaQuestion: any, question: QuestionBase): any {

--- a/src/app/form-entry/helpers/historical-expression-helper-service.ts
+++ b/src/app/form-entry/helpers/historical-expression-helper-service.ts
@@ -1,23 +1,24 @@
+import { Injectable } from '@angular/core';
+
 import { HistoricalEncounterDataService } from '../services/historical-encounter-data.service';
-import { MockObs } from '../../mock/mock-obs';
 import { JsExpressionHelper } from './js-expression-helper';
 import { Runnable, ExpressionRunner } from '../expression-runner/expression-runner';
 import { AfeFormControl } from '../../abstract-controls-extension/afe-form-control';
 
+@Injectable()
 export class HistoricalHelperService {
 
   constructor() {
   }
 
-  public evaluate(expr: string): any {
-
-    let obs: MockObs = new MockObs();
+  public evaluate(expr: string, dataSources: any): any {
+    let HD = new HistoricalEncounterDataService();
+    HD.registerEncounters('prevEnc', dataSources['rawPrevEnc']);
     let deps: any = {
-      HD: new HistoricalEncounterDataService('prevEnc', obs.getObs())
+      HD: HD
     };
 
     let helper = new JsExpressionHelper();
-
     let control: AfeFormControl = new AfeFormControl();
     let runner: ExpressionRunner = new ExpressionRunner();
     let runnable: Runnable = runner.getRunnable(expr, control, helper.helperFunctions, deps);

--- a/src/app/form-entry/services/historical-encounter-data.service.ts
+++ b/src/app/form-entry/services/historical-encounter-data.service.ts
@@ -1,79 +1,56 @@
+import { Injectable } from '@angular/core';
 import * as _ from 'lodash';
 
+@Injectable()
 export class HistoricalEncounterDataService {
 
-  store: any = {};
+  dataSources: any = {};
 
-  encounters: any;
-
-  name: string;
-
-  constructor(name: string, openmrsEncounters: any) {
-
-    this.encounters = openmrsEncounters;
-    this.name = name;
-    this.registerEncounters();
+  constructor() {
   }
 
-  registerEncounters() {
-
+  registerEncounters(name: string, encounters: any) {
     let encStore: any = {
       data: [],
-
       getValue: (key: string, index = 0): any => {
-
         let pathArray = key.split('.');
-
         if (pathArray.length > 0) {
           return this.getFirstValue(pathArray, encStore.data[index]);
         }
         return encStore.data[index][key];
       },
-
       getAllObjects: () => {
         return encStore.data;
       },
-
-
       getSingleObject: (index = 0) => {
-
         return encStore.data[index];
       }
     };
 
-
-    if (_.isArray(this.encounters)) {
+    if (_.isArray(encounters)) {
       let group: Array<any> = [];
-      _.each(this.encounters, (encounter) => {
-        group.push(this._transformEncounter(encounter));
+      _.each(encounters, (encounter) => {
+          group.push(this._transformEncounter(encounter));
       });
 
       // Sort them in reverse chronological order
       encStore.data = _.sortBy(group, 'encounterDatetime').reverse();
     } else {
       // Assume a single openmrs rest encounter object.
-      encStore.data.push(this._transformEncounter(this.encounters));
+      encStore.data.push(this._transformEncounter(encounters));
     }
 
-    this.putObject(this.name, encStore);
+    this.putObject(name, encStore);
 
   }
 
   putObject(name, object): void {
-    this.store[name] = object;
+    this.dataSources[name] = object;
   }
 
   getObject(name: string): any {
-    return this.store[name] || null;
+    return this.dataSources[name] || null;
   }
-
-  hasKey(name: string): boolean {
-    return _.has(this.store, name);
-  };
-
-  removeAllObjects(): void {
-    this.store = {};
-  };
 
   getFirstValue(path: Array<string>, object: any) {
 
@@ -112,9 +89,12 @@ export class HistoricalEncounterDataService {
   }
 
   private _transformEncounter(encounter: any) {
+    if (_.isNil(encounter)) {
+      return;
+    }
     // Transform encounter Level details to key value pairs.
     let prevEncounter: any = {
-      encounterDatetime: encounter.encounterDatetime,
+      encounterDatetime: encounter.encounterDatetime
     };
 
     if (encounter.location && encounter.location.uuid) {

--- a/src/app/form-entry/services/historical-encounter-data.spec.ts
+++ b/src/app/form-entry/services/historical-encounter-data.spec.ts
@@ -12,7 +12,9 @@ describe('Historical Encounter Data Service', () => {
         {
           provide: HistoricalEncounterDataService,
           useFactory: () => {
-            return new HistoricalEncounterDataService('prevEnc', obs.getObs());
+            let HD = new HistoricalEncounterDataService();
+            HD.registerEncounters('prevEnc', obs.getObs());
+            return HD;
           },
           deps: []
         }
@@ -27,7 +29,6 @@ describe('Historical Encounter Data Service', () => {
 
   it('should have "prevEnc" registered as key', () => {
     let service: HistoricalEncounterDataService = TestBed.get(HistoricalEncounterDataService);
-    expect(service.name).toEqual('prevEnc');
     expect(service.getObject('prevEnc').getSingleObject()).toEqual(obs.getExpected());
   });
 
@@ -83,7 +84,8 @@ describe('Historical Encounter Data Service', () => {
       }]
     }];
 
-    let service: HistoricalEncounterDataService = new HistoricalEncounterDataService('prevEncs', encArray);
+    let service: HistoricalEncounterDataService = new HistoricalEncounterDataService();
+    service.registerEncounters('prevEncs', encArray);
     let store: Array<any> = service.getObject('prevEncs').getAllObjects();
     expect(store.length).toEqual(encArray.length);
     expect(store[0].encounterDatetime).toEqual(encArray[1].encounterDatetime);


### PR DESCRIPTION
NGPOC-86: Fetch and register previous encounter for historical values.

This PR includes a fix to the test failures it created in ng2-amrs. I have tested from ng2-amrs by editing the form-entry module and it was able to run all the tests successfully.