### PR TITLE
NGPOC-323:Voiding Lab Order

### DIFF
--- a/src/app/form-entry/value-adapters/order.adapter.ts
+++ b/src/app/form-entry/value-adapters/order.adapter.ts
@@ -82,11 +82,12 @@ export class OrderValueAdapter implements ValueAdapter {
                     orderNumber: o.orderNumber,
                     orderUuid: o.uuid,
                     voided: o.voided,
+                    dateVoided: o.auditInfo.dateVoided
                 };
             });
 
             return existingOrders = _.filter(existingOrders, (order: any) => {
-                if (order.voided === true) {
+                if (order.voided === true || order.dateVoided) {
                     return false;
                 } else {
                     return true;

--- a/src/app/mock/orders.json
+++ b/src/app/mock/orders.json
@@ -82,7 +82,9 @@
         {
             "uuid": "order-1-uuid",
             "orderNumber": "ORD-13737",
-            "voided": true,
+            "auditInfo": {
+                "dateVoided": "2017-01-01"
+            },
             "patient": {
                 "uuid": "b4ddd369-bec5-446e-b8f8-47fd5567b295",
                 "display": "234750205-2 - Robai Test Robai",
@@ -165,6 +167,9 @@
         {
             "uuid": "order-1-uuid",
             "orderNumber": "ORD-13738",
+            "auditInfo": {
+                "dateVoided": ""
+            },
             "patient": {
                 "uuid": "b4ddd369-bec5-446e-b8f8-47fd5567b295",
                 "display": "234750205-2 - Robai Test Robai",
@@ -247,6 +252,9 @@
         {
             "uuid": "order-2-uuid",
             "orderNumber": "ORD-13739",
+            "auditInfo": {
+                "dateVoided": ""
+            },
             "patient": {
                 "uuid": "b4ddd369-bec5-446e-b8f8-47fd5567b295",
                 "display": "234750205-2 - Robai Test Robai",


### PR DESCRIPTION
Revised voided orders filtering to alternatively use dataVoided as we realized the new order resource does not include voided property when returning an existing order.