### PR TITLE
APTS-745 : User Not Able To Search Location With Three Letters

### DIFF
--- a/src/components/remote-select/remote-select.component.ts
+++ b/src/components/remote-select/remote-select.component.ts
@@ -106,8 +106,8 @@ export class RemoteSelectComponent implements OnInit, ControlValueAccessor {
     }
 
     canSearch(searchText: string) {
-        return (searchText.length - this.searchText.length >= 3 ||
-            (searchText.length - this.searchText.length <= 3 && searchText !== '')) && this.loading === false;
+        return (searchText.length - this.searchText.length >= 2 ||
+            (searchText.length - this.searchText.length <= 2 && searchText !== '')) && this.loading === false;
     }
 
     // this is the initial value set to the component

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -166,7 +166,7 @@ export class SelectComponent
 
     onSingleFilterInput(term: string) {
         setTimeout(() => {
-            if (term.length > 3) {
+            if (term.length > 2) {
                 this.typed.emit(term);
             }
         }, 500);


### PR DESCRIPTION
This PR fixes issue where users are not able to search for locations with less than 3 letters e.g Soy.Thus not able to add the location in encounter form